### PR TITLE
Basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./mz2.py", "--help" ]


### PR DESCRIPTION
Doesn’t work with —-gui on OS X without Quartz.

Build with:
docker build -t objcode/mz2 .
docker run -it objcode/mz2 bash

Then follow talks.txt commands (without —gui).